### PR TITLE
When writing a number in 4 bytes, cast the number to uint32 before adding the two trailing size bits.

### DIFF
--- a/subunit.go
+++ b/subunit.go
@@ -251,8 +251,7 @@ func writeNumber(b io.Writer, num int) (err error) {
 	case num < 1073741824: // 2^(32-2):
 		// Fits in four bytes.
 		// Set the size to 11.
-		var size uint32 = 0xc0000000
-		binary.Write(b, binary.BigEndian, uint32(num)|size)
+		binary.Write(b, binary.BigEndian, uint32(num)|0xc0000000)
 	default:
 		err = &ErrNumber{num}
 	}

--- a/subunit.go
+++ b/subunit.go
@@ -252,7 +252,7 @@ func writeNumber(b io.Writer, num int) (err error) {
 		// Fits in four bytes.
 		// Set the size to 11.
 		var size uint32 = 0xc0000000
-		binary.Write(b, binary.BigEndian, uint32(uint32(num)|size))
+		binary.Write(b, binary.BigEndian, uint32(num)|size)
 	default:
 		err = &ErrNumber{num}
 	}

--- a/subunit.go
+++ b/subunit.go
@@ -251,7 +251,8 @@ func writeNumber(b io.Writer, num int) (err error) {
 	case num < 1073741824: // 2^(32-2):
 		// Fits in four bytes.
 		// Set the size to 11.
-		binary.Write(b, binary.BigEndian, uint32(num|0xc0000000))
+		var size uint32 = 0xc0000000
+		binary.Write(b, binary.BigEndian, uint32(uint32(num)|size))
 	default:
 		err = &ErrNumber{num}
 	}


### PR DESCRIPTION
Running the snappy integration tests in the canonical lab I got:
../../testing-cabal/subunit-go/subunit.go:254: constant 3221225472 overflows int
I think defining the size as uint32 explicitly will prevent this error.
